### PR TITLE
Fixed compilation error with new isl 0.20

### DIFF
--- a/gcc/graphite.h
+++ b/gcc/graphite.h
@@ -37,6 +37,8 @@ along with GCC; see the file COPYING3.  If not see
 #include <isl/schedule.h>
 #include <isl/ast_build.h>
 #include <isl/schedule_node.h>
+#include <isl/id.h>
+#include <isl/space.h>
 
 typedef struct poly_dr *poly_dr_p;
 


### PR DESCRIPTION
**System Configuration**
```
LSB Version:      n/a
Distributor ID:   ManjaroLinux
Description:      Manjaro Linux
Release:          22.0.0
Codename:         Sikari

Linux trojan 5.15.76-1-MANJARO #1 SMP PREEMPT Sat Oct 29 1:22:16 UTC 2022 x86_64 GNU/Linux
```

* gcc (GCC) 12.2.0
* libisl.so.23

**Problem**
On my system with libisl.so=23 I get the some of the following errors:
```
/mempool/toolchain/riscv-gnu-toolchain/build/../riscv-gcc/gcc/graphite-isl-ast-to-gimple.c:668:53: error: ‘isl_id_get_user’ was not declared in this scope; did you mean ‘isl_arg_user’?
  668 |       ast_build_info *for_info = (ast_build_info *) isl_id_get_user (id);
      |                                                     ^~~~~~~~~~~~~~~
      |                                                     isl_arg_user

/mempool/toolchain/riscv-gnu-toolchain/build/../riscv-gcc/gcc/graphite-optimize-isl.c:57:19: error: ‘isl_space_dim’ was not declared in this scope; did you mean ‘isl_space’?
   57 |   unsigned dims = isl_space_dim (space, isl_dim_set);
      |                   ^~~~~~~~~~~~~
      |                   isl_space

```

**Solution**
- See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86724

The changes should not affect older systems and was already tested on the IIS workstations.